### PR TITLE
Parse core count as an int when set manually

### DIFF
--- a/hcov-229e/build_hcov_229e_pe_pipeline.py
+++ b/hcov-229e/build_hcov_229e_pe_pipeline.py
@@ -487,6 +487,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",

--- a/hcov-hku1/build_hcov_hku1_pe_pipeline.py
+++ b/hcov-hku1/build_hcov_hku1_pe_pipeline.py
@@ -487,6 +487,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",

--- a/hcov-nl63/build_hcov_nl63_pe_pipeline.py
+++ b/hcov-nl63/build_hcov_nl63_pe_pipeline.py
@@ -487,6 +487,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",

--- a/hcov-oc43/build_hcov_oc43_pe_pipeline.py
+++ b/hcov-oc43/build_hcov_oc43_pe_pipeline.py
@@ -485,6 +485,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",

--- a/human/build-hg38-pipeline.py
+++ b/human/build-hg38-pipeline.py
@@ -1708,6 +1708,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",

--- a/sars-cov-2/build_sars_cov2_se_pipeline.py
+++ b/sars-cov-2/build_sars_cov2_se_pipeline.py
@@ -484,6 +484,7 @@ def defineArguments() -> Namespace:
     parser.add_argument(
         "-z",
         "--cores",
+        type=int,
         action="store",
         dest="cores",
         metavar="CPU_COUNT",


### PR DESCRIPTION
Core count was being parsed as a string instead of an int, so operations like `cores / threads` and `cores * 2` were either erroring or using string arithmetic instead of integer arithmetic.