### PR TITLE
Skip variant calling if coverage is too low

### DIFF
--- a/hcov/bio_methods.py
+++ b/hcov/bio_methods.py
@@ -542,7 +542,6 @@ fi
     )
 
 
-
 def buildBamFilePath(options: OptionsDict, reference, type: Literal["aligned"] | Literal["sorted"]) -> str:
     return "{PIPELINE}/{SAMPLE}.{ORGANISM}.{TYPE}.bam".format(
         PIPELINE=options["pipeline"],
@@ -550,6 +549,7 @@ def buildBamFilePath(options: OptionsDict, reference, type: Literal["aligned"] |
         ORGANISM=reference["common"],
         TYPE=type
     )
+
 
 def commonPipeline(
     script: TextIOWrapper,
@@ -570,7 +570,6 @@ def commonPipeline(
 
         align(script, options, reference)
         sortAndExtractUnmapped(script, options, reference)
-
         runVariantPipeline(script, options, reference)
 
         if options["runQc"] == True:

--- a/hcov/bio_methods.py
+++ b/hcov/bio_methods.py
@@ -52,8 +52,6 @@ fi
         )
     )
 
-    return sorted
-
 
 def extractUmappedReads(script: TextIOWrapper, options: OptionsDict, reference):
     pipeline = options["pipeline"]

--- a/hcov/bio_methods.py
+++ b/hcov/bio_methods.py
@@ -193,7 +193,7 @@ ORGANISM_COVERAGE=$(samtools coverage -d 0 --reference {REFERENCE_ASSEMBLY} {SOR
 if (( $(echo "${{ORGANISM_COVERAGE}} >= 95.0" | bc -l) )); then
 """.format(
         REFERENCE_ASSEMBLY=reference["assembly"],
-        SORTED=buildBamFilePath(options, reference, "aligned"),
+        SORTED=buildBamFilePath(options, reference, "sorted"),
     )
 )
     callVariants(script, options, reference)

--- a/hcov/common.py
+++ b/hcov/common.py
@@ -42,9 +42,10 @@ reset=$(tput sgr0)
     script.write("#\n")
     script.write(
         """
+CURRENT_REFERENCE='*';
 function logthis() {{
   NOW=$(date "+%Y-%m-%d %H:%M:%S")
-  echo -e "[${{NOW}}] ${{1}}"
+  echo -e "[${{NOW}}] (${{CURRENT_REFERENCE}}) ${{1}}"
 }}
 
 # deal with really large fastq files

--- a/hcov/common.py
+++ b/hcov/common.py
@@ -45,7 +45,7 @@ reset=$(tput sgr0)
 CURRENT_REFERENCE='*';
 function logthis() {{
   NOW=$(date "+%Y-%m-%d %H:%M:%S")
-  echo -e "[${{NOW}}] (${{CURRENT_REFERENCE}}) ${{1}}"
+  echo -e "[${{NOW}} - {SAMPLE} - ${{CURRENT_REFERENCE}}] ${{1}}"
 }}
 
 # deal with really large fastq files
@@ -67,7 +67,8 @@ export BCFTOOLS_PLUGINS={WORKING}/libexec/bcftools
 
 # handy path
 export PATH={WORKING}/bin/FastQC:{WORKING}/bin:$PATH\n""".format(
-            WORKING=options["working"]
+            SAMPLE=options["sample"],
+            WORKING=options["working"],
         )
     )
     script.write("\n")

--- a/hcov/paired_end.py
+++ b/hcov/paired_end.py
@@ -216,7 +216,7 @@ def runBwaAligner(
 #
 # align the input files
 #
-if [[ ! -f {PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam ]]; then
+if [[ ! -f {ALIGNED} ]]; then
     logthis "${{yellow}}Running aligner${{reset}}"
 
     {ALIGNER} mem \\
@@ -226,11 +226,11 @@ if [[ ! -f {PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam ]]; then
         {REFERENCE_ASSEMBLY} \\
         {R1} \\
         {R2} | 
-    samtools view -Sb -@ 4 - >{PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam
+    samtools view -Sb -@ 4 - >{ALIGNED}
 
     logthis "${{yellow}}Alignment completed${{reset}}"
 else
-    logthis "{PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam, aligned temp file found, ${{green}}skipping${{reset}}"
+    logthis "{ALIGNED}, aligned temp file found, ${{green}}skipping${{reset}}"
 fi
 
 """.format(
@@ -241,6 +241,7 @@ fi
             REFERENCE_ASSEMBLY=referenceAssembly,
             ORGANISM=reference["common"],
             SAMPLE=sample,
+            ALIGNED=buildBamFilePath(options, reference, "aligned"),
             THREADS=threads,
             PIPELINE=pipeline,
             BIN=bin,

--- a/hcov/single_end.py
+++ b/hcov/single_end.py
@@ -128,7 +128,7 @@ def runBwaAligner(
 #
 # align the input files
 #
-if [[ ! -f {PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam ]]; then
+if [[ ! -f {ALIGNED} ]]; then
     logthis "${{yellow}}Running aligner${{reset}}"
 
     {ALIGNER} mem \\
@@ -140,11 +140,11 @@ if [[ ! -f {PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam ]]; then
         -a \\
         {REFERENCE_ASSEMBLY} \\
         {R1} | 
-    samtools view -Sb -@ 4 - >{PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam
+    samtools view -Sb -@ 4 - >{ALIGNED}
 
     logthis "${{yellow}}Alignment completed${{reset}}"
 else
-    logthis "{PIPELINE}/{SAMPLE}.{ORGANISM}.aligned.bam, aligned temp file found, ${{green}}skipping${{reset}}"
+    logthis "{ALIGNED}, aligned temp file found, ${{green}}skipping${{reset}}"
 fi
 
 """.format(
@@ -154,6 +154,7 @@ fi
             REFERENCE_ASSEMBLY=referenceAssembly,
             ORGANISM=reference["common"],
             SAMPLE=sample,
+            ALIGNED=buildBamFilePath(options, reference, "aligned"),
             THREADS=threads,
             PIPELINE=pipeline,
             BIN=bin,


### PR DESCRIPTION
Also update `logthis` to print the sample and `$CURRENT_REFERENCE` as part of the log message for easier debugging.